### PR TITLE
Handle missing output directory when exporting results

### DIFF
--- a/export_result.py
+++ b/export_result.py
@@ -1,9 +1,21 @@
 import csv
+import os
 
-def export_result(result_data): 
-    file_path = 'data/result.csv'
-    text = result_data
-    
-    with open(file_path, 'w', encoding='utf-8') as f:
-        rows = csv.writer(f)
-        rows.writerows(result_data)
+
+def export_result(result_data):
+    """Export converted name data to ``data/result.csv``.
+
+    The original implementation expected the ``data`` directory to already
+    exist, which caused a ``FileNotFoundError`` when it didn't.  Creating the
+    directory on the fly makes the function more robust and allows it to be
+    used in a fresh environment without manual setup.
+    """
+
+    file_path = os.path.join("data", "result.csv")
+
+    # Ensure the output directory exists before attempting to write the file
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+    with open(file_path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerows(result_data)


### PR DESCRIPTION
## Summary
- avoid FileNotFoundError by creating the `data` directory before writing
- document and simplify result exporting

## Testing
- `python -m py_compile export_result.py import_csv.py parse_name.py main.py`
- `python - <<'PY'
from export_result import export_result
export_result([['foo', 1, 'bar', 2]])
print('written')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6895fb3515f8832cb05c6228af3b5600