### PR TITLE
Fix variable name typo

### DIFF
--- a/parse_name.py
+++ b/parse_name.py
@@ -11,14 +11,14 @@ def parse_name(csv_text):
         pair_result = []
         
         for category in result: 
-            sentense_Roman = ''
+            sentence_roman = ''
             
             for item in category: 
                 chunk_Roman = item['hepburn']
-                sentense_Roman += ''.join(chunk_Roman)
+                sentence_roman += ''.join(chunk_Roman)
                 
-            typing_count = len(sentense_Roman)
-            pair_result.extend(tuple([sentense_Roman, typing_count]))
+            typing_count = len(sentence_roman)
+            pair_result.extend(tuple([sentence_roman, typing_count]))
 
         csv_result.append(pair_result)
         print(pair_result)


### PR DESCRIPTION
## Summary
- rename `sentense_Roman` to `sentence_roman`
- ensure `typing_count` references `sentence_roman`

## Testing
- `python -m py_compile parse_name.py`


------
https://chatgpt.com/codex/tasks/task_e_6895fcdab744832c87c23b0b483e3f48