### PR TITLE
docs: broaden Python version requirement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- [pykakasi](https://codeberg.org/miurahr/pykakasi) (to parse Japanese phrase, supports **python 3.6 - 3.9**)
+- [pykakasi](https://codeberg.org/miurahr/pykakasi) (to parse Japanese phrase; requires **Python 3.7+**. The library advertises support for Python 3.6–3.9.)
 - installing CSV file from [external pastebin](https://pastebin.com/TsMzbQi9)  
 (Title and genre data might be KONAMI's Intellectual Property. In order to keep this repository as MIT License, *polluted* material would not be included.)
 


### PR DESCRIPTION
## Summary
- clarify README requirement to Python 3.7+
- note pykakasi advertises Python 3.6–3.9 support

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6895fddcd8e0832c8b66110a56dec51e