### PR TITLE
Add unit test for parse_name and include pytest dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Deprecated==1.2.13
 jaconv==0.3.1
 pykakasi==2.2.1
 wrapt==1.14.1
+pytest==8.4.1

--- a/tests/test_parse_name.py
+++ b/tests/test_parse_name.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from parse_name import parse_name
+
+
+def test_parse_name_returns_romanized_strings_and_counts():
+    data = [["タイトル", "ジャンル"]]
+    expected = [["taitoru", 7, "janru", 5]]
+    assert parse_name(data) == expected


### PR DESCRIPTION
## Summary
- add pytest to requirements
- test parse_name romanization and typing counts using in-memory data

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895fdde4134832c97e43dae451deeba