### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/signoiidx/popn-naming-type-cost/security/code-scanning/1](https://github.com/signoiidx/popn-naming-type-cost/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/pylint.yml` with the minimum required scope.  
For this workflow, the best single fix is to add at workflow root:

- `permissions:`
  - `contents: read`

This preserves existing functionality (checkout + linting) while enforcing least privilege for all jobs in the workflow. No new imports, methods, or dependencies are required—just YAML configuration in the shown file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
